### PR TITLE
Update scanner.py

### DIFF
--- a/custom_components/companion_bt_proxy/scanner.py
+++ b/custom_components/companion_bt_proxy/scanner.py
@@ -2,6 +2,7 @@ from homeassistant.components import bluetooth
 
 import logging
 import base64
+import psutil
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -25,7 +26,7 @@ class CompanionBLEScanner(bluetooth.BaseHaRemoteScanner):
             manufacturer_data=m_data,
             tx_power=data.get("tx_power", 0),
             details=dict(),
-            advertisement_monotonic_time=data.get("timestamp", 0) / 1000, # Milliseconds to fractional seconds
+            advertisement_monotonic_time=((data.get("timestamp", 0) / 1000) - psutil.boot_time()), # Milliseconds to fractional seconds; subtract boot time
         )
 
     async def async_update_sensors(self):


### PR DESCRIPTION
Fixed time sync with Home Assistant by subtracting boot time from timestamp.
It is a solution to the issue here: https://github.com/kvj/hass_Bluetooth_Proxy/issues/3