### PR TITLE
refactor: centralize configuration keys in constants

### DIFF
--- a/custom_components/companion_bt_proxy/__init__.py
+++ b/custom_components/companion_bt_proxy/__init__.py
@@ -1,22 +1,27 @@
+"""The Companion Bluetooth Proxy integration."""
 from __future__ import annotations
-from .constants import DOMAIN, PLATFORMS
-from .scanner import CompanionBLEScanner
 
-from homeassistant.core import HomeAssistant
-from homeassistant.helpers.typing import ConfigType
-from homeassistant.components import webhook
-
-import voluptuous as vol
 import logging
 
 from aiohttp.web import json_response
+import voluptuous as vol
+
+from homeassistant.components import webhook
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.typing import ConfigType
+
+from .constants import DOMAIN, PLATFORMS
+from .scanner import CompanionBLEScanner
 
 _LOGGER = logging.getLogger(__name__)
 
-CONFIG_SCHEMA = vol.Schema({
-    DOMAIN: vol.Schema({
-    }, extra=vol.ALLOW_EXTRA),
-}, extra=vol.ALLOW_EXTRA)
+CONFIG_SCHEMA = vol.Schema(
+    {
+        DOMAIN: vol.Schema({}, extra=vol.ALLOW_EXTRA),
+    },
+    extra=vol.ALLOW_EXTRA,
+)
+
 
 async def _async_handle_webhook(hass, webhook_id, request):
     try:
@@ -25,13 +30,21 @@ async def _async_handle_webhook(hass, webhook_id, request):
         _LOGGER.warning(f"Invalid JSON in Webhook")
         return json_response([])
     _LOGGER.debug(f"JSON: {message}")
-    if scanner := hass.data[DOMAIN]["scanners"].get(hass.data[DOMAIN]["webhooks"].get(webhook_id)):
+    if scanner := hass.data[DOMAIN]["scanners"].get(
+        hass.data[DOMAIN]["webhooks"].get(webhook_id)
+    ):
         for item in message:
             await scanner.async_process_json(item)
         await scanner.async_update_sensors()
     else:
         _LOGGER.warning(f"No scanner registered for webhook {webhook_id}")
     return json_response([])
+
+
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    hass.data[DOMAIN] = {"scanners": {}, "webhooks": {}}
+    return True
+
 
 async def async_setup_entry(hass: HomeAssistant, entry):
     data = entry.as_dict()["data"]
@@ -41,11 +54,14 @@ async def async_setup_entry(hass: HomeAssistant, entry):
     await scanner.async_load(hass)
     entry.runtime_data = scanner
     hass.data[DOMAIN]["scanners"][entry.entry_id] = scanner
-    webhook.async_register(hass, DOMAIN, "Companion BT Proxy", hook_id, _async_handle_webhook)
+    webhook.async_register(
+        hass, DOMAIN, "Companion BT Proxy", hook_id, _async_handle_webhook
+    )
     _LOGGER.debug(f"async_setup_entry() Webhook: {hook_id}")
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
+
 
 async def async_unload_entry(hass: HomeAssistant, entry):
     scanner = entry.runtime_data
@@ -59,8 +75,4 @@ async def async_unload_entry(hass: HomeAssistant, entry):
     await scanner.async_unload(hass)
     hass.data[DOMAIN]["scanners"].pop(entry.entry_id)
     entry.runtime_data = None
-    return True
-
-async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
-    hass.data[DOMAIN] = {"scanners": {}, "webhooks": {}}
     return True

--- a/custom_components/companion_bt_proxy/__init__.py
+++ b/custom_components/companion_bt_proxy/__init__.py
@@ -10,7 +10,7 @@ from homeassistant.components import webhook
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.typing import ConfigType
 
-from .constants import DOMAIN, PLATFORMS
+from .constants import CONF_WEBHOOK, DOMAIN, PLATFORMS
 from .scanner import CompanionBLEScanner
 
 _LOGGER = logging.getLogger(__name__)
@@ -48,7 +48,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
 async def async_setup_entry(hass: HomeAssistant, entry):
     data = entry.as_dict()["data"]
-    hook_id = data["webhook"]
+    hook_id = data[CONF_WEBHOOK]
     hass.data[DOMAIN]["webhooks"][hook_id] = entry.entry_id
     scanner = CompanionBLEScanner(hass, entry)
     await scanner.async_load(hass)
@@ -66,7 +66,7 @@ async def async_setup_entry(hass: HomeAssistant, entry):
 async def async_unload_entry(hass: HomeAssistant, entry):
     scanner = entry.runtime_data
     data = entry.as_dict()["data"]
-    hook_id = data["webhook"]
+    hook_id = data[CONF_WEBHOOK]
     webhook.async_unregister(hass, hook_id)
 
     await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/custom_components/companion_bt_proxy/config_flow.py
+++ b/custom_components/companion_bt_proxy/config_flow.py
@@ -1,34 +1,36 @@
+"""Config flow for Companion Bluetooth Proxy integration."""
+from __future__ import annotations
+
+import logging
+
+import voluptuous as vol
+
 from homeassistant import config_entries
-import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.selector import selector
-from homeassistant.helpers import device_registry, network
 from homeassistant.components import webhook
+from homeassistant.helpers.selector import selector
 
 from .constants import DOMAIN
 
-import voluptuous as vol
-import logging
-
 _LOGGER = logging.getLogger(__name__)
+
 
 def _create_webhook(hass) -> str:
     id = webhook.async_generate_id()
     url = webhook.async_generate_url(hass, id)
     return id, url
 
+
 def _create_schema(hass):
     hook_id, hook_url = _create_webhook(hass)
-    schema = vol.Schema({
-        vol.Required("name"): selector({
-            "text": {}
-        }),
-        vol.Required("webhook", default=hook_id): selector({
-            "text": {}
-        }),
-        vol.Optional("webhook_url", default=hook_url): selector({
-            "text": { "type": "url" }
-        }),
-    })
+    schema = vol.Schema(
+        {
+            vol.Required("name"): selector({"text": {}}),
+            vol.Required("webhook", default=hook_id): selector({"text": {}}),
+            vol.Optional("webhook_url", default=hook_url): selector(
+                {"text": {"type": "url"}}
+            ),
+        }
+    )
     return schema
 
 
@@ -36,9 +38,17 @@ class ConfigFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_user(self, user_input=None):
         if user_input is None:
-            return self.async_show_form(step_id="user", data_schema=_create_schema(self.hass))
+            return self.async_show_form(
+                step_id="user", data_schema=_create_schema(self.hass)
+            )
         else:
             _LOGGER.debug(f"Input: {user_input}")
             await self.async_set_unique_id(user_input["name"])
             self._abort_if_unique_id_configured()
-            return self.async_create_entry(title=user_input["name"], options={}, data={"webhook": user_input["webhook"],})
+            return self.async_create_entry(
+                title=user_input["name"],
+                options={},
+                data={
+                    "webhook": user_input["webhook"],
+                },
+            )

--- a/custom_components/companion_bt_proxy/config_flow.py
+++ b/custom_components/companion_bt_proxy/config_flow.py
@@ -9,7 +9,7 @@ from homeassistant import config_entries
 from homeassistant.components import webhook
 from homeassistant.helpers.selector import selector
 
-from .constants import DOMAIN
+from .constants import CONF_WEBHOOK, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -25,7 +25,7 @@ def _create_schema(hass):
     schema = vol.Schema(
         {
             vol.Required("name"): selector({"text": {}}),
-            vol.Required("webhook", default=hook_id): selector({"text": {}}),
+            vol.Required(CONF_WEBHOOK, default=hook_id): selector({"text": {}}),
             vol.Optional("webhook_url", default=hook_url): selector(
                 {"text": {"type": "url"}}
             ),
@@ -49,6 +49,6 @@ class ConfigFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 title=user_input["name"],
                 options={},
                 data={
-                    "webhook": user_input["webhook"],
+                    CONF_WEBHOOK: user_input[CONF_WEBHOOK],
                 },
             )

--- a/custom_components/companion_bt_proxy/constants.py
+++ b/custom_components/companion_bt_proxy/constants.py
@@ -2,4 +2,10 @@
 from __future__ import annotations
 
 DOMAIN = "companion_bt_proxy"
-PLATFORMS = ["sensor"]
+PLATFORMS = ("sensor",)  # Using tuple since this is immutable
+
+# Configuration keys
+CONF_WEBHOOK = "webhook"
+
+# Attribute keys
+ATTR_WEBHOOK_ID = "webhook_id"

--- a/custom_components/companion_bt_proxy/constants.py
+++ b/custom_components/companion_bt_proxy/constants.py
@@ -1,2 +1,5 @@
+"""Constants for the Companion Bluetooth Proxy integration."""
+from __future__ import annotations
+
 DOMAIN = "companion_bt_proxy"
 PLATFORMS = ["sensor"]

--- a/custom_components/companion_bt_proxy/manifest.json
+++ b/custom_components/companion_bt_proxy/manifest.json
@@ -9,5 +9,5 @@
   "requirements": ["bluetooth-data-tools"],
   "iot_class": "local_push",
   "config_flow": true,
-  "version": "0.1.3"
+  "version": "0.1.4"
 }

--- a/custom_components/companion_bt_proxy/manifest.json
+++ b/custom_components/companion_bt_proxy/manifest.json
@@ -6,7 +6,7 @@
   "after_dependencies": ["cloud"],
   "dependencies": ["webhook", "bluetooth"],
   "codeowners": ["@kvj"],
-  "requirements": [],
+  "requirements": ["bluetooth-data-tools"],
   "iot_class": "local_push",
   "config_flow": true,
   "version": "0.1.3"

--- a/custom_components/companion_bt_proxy/scanner.py
+++ b/custom_components/companion_bt_proxy/scanner.py
@@ -33,7 +33,7 @@ class CompanionBLEScanner(bluetooth.BaseHaRemoteScanner):
             await s.async_on_scanner_update(self)
 
     async def async_load(self, hass):
-        self._unload_callback = bluetooth.async_register_scanner(hass, self, False)
+        self._unload_callback = bluetooth.async_register_scanner(hass, self, 0)
 
     async def async_unload(self, hass):
         self._unload_callback()

--- a/custom_components/companion_bt_proxy/scanner.py
+++ b/custom_components/companion_bt_proxy/scanner.py
@@ -1,31 +1,44 @@
-from homeassistant.components import bluetooth
-from bluetooth_data_tools import monotonic_time_coarse
+"""Bluetooth scanner implementation for Companion Bluetooth Proxy."""
+from __future__ import annotations
 
-import logging
 import base64
+import logging
 import time
 
+from bluetooth_data_tools import monotonic_time_coarse
+
+from homeassistant.components import bluetooth
+
 _LOGGER = logging.getLogger(__name__)
+
 
 class CompanionBLEScanner(bluetooth.BaseHaRemoteScanner):
 
     def __init__(self, hass, entry):
-        self._connector = bluetooth.HaBluetoothConnector(client=None, source=entry.entry_id, can_connect=lambda: False)
+        self._connector = bluetooth.HaBluetoothConnector(
+            client=None, source=entry.entry_id, can_connect=lambda: False
+        )
         super().__init__(entry.entry_id, entry.title, self._connector, False)
         self._sensors = []
 
     async def async_process_json(self, data: dict):
-        service_data = {key: base64.b64decode(value) for (key, value) in data.get("service_data", {}).items()}
-        m_data = {int(key, 10): base64.b64decode(value) for (key, value) in data.get("manufacturer_data", {}).items()}
+        service_data = {
+            key: base64.b64decode(value)
+            for (key, value) in data.get("service_data", {}).items()
+        }
+        m_data = {
+            int(key, 10): base64.b64decode(value)
+            for (key, value) in data.get("manufacturer_data", {}).items()
+        }
         _LOGGER.debug(f"async_process_json: {data}, {service_data}, {m_data}")
-        
+
         # Convert received timestamp to monotonic time
         current_monotonic = monotonic_time_coarse()
         received_timestamp_seconds = data.get("timestamp", 0) / 1000
         current_time_seconds = time.time()
         time_offset = current_time_seconds - received_timestamp_seconds
         advertisement_monotonic_time = current_monotonic - time_offset
-        
+
         self._async_on_advertisement(
             address=data["address"],
             rssi=data.get("rssi", 0),

--- a/custom_components/companion_bt_proxy/scanner.py
+++ b/custom_components/companion_bt_proxy/scanner.py
@@ -1,7 +1,9 @@
 from homeassistant.components import bluetooth
+from bluetooth_data_tools import monotonic_time_coarse
 
 import logging
 import base64
+import time
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -16,6 +18,14 @@ class CompanionBLEScanner(bluetooth.BaseHaRemoteScanner):
         service_data = {key: base64.b64decode(value) for (key, value) in data.get("service_data", {}).items()}
         m_data = {int(key, 10): base64.b64decode(value) for (key, value) in data.get("manufacturer_data", {}).items()}
         _LOGGER.debug(f"async_process_json: {data}, {service_data}, {m_data}")
+        
+        # Convert received timestamp to monotonic time
+        current_monotonic = monotonic_time_coarse()
+        received_timestamp_seconds = data.get("timestamp", 0) / 1000
+        current_time_seconds = time.time()
+        time_offset = current_time_seconds - received_timestamp_seconds
+        advertisement_monotonic_time = current_monotonic - time_offset
+        
         self._async_on_advertisement(
             address=data["address"],
             rssi=data.get("rssi", 0),
@@ -25,7 +35,7 @@ class CompanionBLEScanner(bluetooth.BaseHaRemoteScanner):
             manufacturer_data=m_data,
             tx_power=data.get("tx_power", 0),
             details=dict(),
-            advertisement_monotonic_time=data.get("timestamp", 0) / 1000, # Milliseconds to fractional seconds
+            advertisement_monotonic_time=advertisement_monotonic_time,
         )
 
     async def async_update_sensors(self):

--- a/custom_components/companion_bt_proxy/sensor.py
+++ b/custom_components/companion_bt_proxy/sensor.py
@@ -1,15 +1,21 @@
+"""Sensor platform for Companion Bluetooth Proxy integration."""
+from __future__ import annotations
+
+import logging
+
 from homeassistant.components import sensor
-from homeassistant.util import dt
 from homeassistant.helpers.entity import EntityCategory
+from homeassistant.util import dt
 
 from .constants import DOMAIN
 
-import logging
 _LOGGER = logging.getLogger(__name__)
+
 
 async def async_setup_entry(hass, entry, async_setup_entities):
     scanner = entry.runtime_data
     async_setup_entities([_LastUpdate(scanner, entry)])
+
 
 class _LastUpdate(sensor.SensorEntity):
 
@@ -40,7 +46,7 @@ class _LastUpdate(sensor.SensorEntity):
     def device_info(self):
         return {
             "identifiers": {
-                ("entry_id", self._entry_id), 
+                ("entry_id", self._entry_id),
             },
             "name": self._device_name,
         }


### PR DESCRIPTION
## Description
This PR centralizes hardcoded configuration key strings into constants to prevent typos and improve maintainability. The PLATFORMS list is also changed to a tuple since it's immutable.

## Changes
- Add `CONF_WEBHOOK` constant to centralize "webhook" string usage
- Add `ATTR_WEBHOOK_ID` constant for future diagnostic attributes
- Change `PLATFORMS` from list to tuple (immutable)
- Update `config_flow.py` to use `CONF_WEBHOOK`
- Update `__init__.py` to use `CONF_WEBHOOK`

## Files Changed
- `custom_components/companion_bt_proxy/constants.py`
- `custom_components/companion_bt_proxy/config_flow.py`
- `custom_components/companion_bt_proxy/__init__.py`

## Breaking Changes
None - internal refactoring only